### PR TITLE
Fixing the lack of "IF NOT EXIST" in influxdb > 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This modules provides integration with the [InfluxDB](https://influxdata.com/) d
         password: ~
         database: test
         retention-policy: autogen
+        create-database: false
     ```
 
 * Create `InfluxDBConnectionFactory` and `InfluxDBTemplate` beans:
@@ -95,3 +96,8 @@ Spring Data InfluxDB uses Maven as its build system.
 ```bash
 mvn clean install
 ```
+
+## Additional Hints
+
+Since InfluxDB 1.0.0 the create-database flag must be set to false due to the removeing of the "IF NOT EXISTS" syntax in queries. 
+See https://github.com/jmxtrans/jmxtrans/issues/489 for example.

--- a/src/main/java/org/springframework/data/influxdb/InfluxDBAccessor.java
+++ b/src/main/java/org/springframework/data/influxdb/InfluxDBAccessor.java
@@ -63,6 +63,11 @@ public class InfluxDBAccessor implements InitializingBean
     return getConnectionFactory().getConnection();
   }
 
+  public boolean getCreateDatabase()
+  {
+    return getConnectionFactory().getProperties().getCreateDatabase();
+  }
+
   @Override
   public void afterPropertiesSet()
   {

--- a/src/main/java/org/springframework/data/influxdb/InfluxDBProperties.java
+++ b/src/main/java/org/springframework/data/influxdb/InfluxDBProperties.java
@@ -37,6 +37,9 @@ public class InfluxDBProperties
   @NotEmpty
   private String retentionPolicy;
 
+  @NotEmpty
+  private boolean createDatabase;
+
   public String getUrl()
   {
     return url;
@@ -87,6 +90,10 @@ public class InfluxDBProperties
     this.retentionPolicy = retentionPolicy;
   }
 
+  public boolean getCreateDatabase() { return createDatabase; }
+
+  public void setCreateDatabase(boolean createDatabase) { this.createDatabase = createDatabase; }
+
   @Override
   public String toString()
   {
@@ -96,6 +103,7 @@ public class InfluxDBProperties
       .add("password", password)
       .add("database", database)
       .add("retentionPolicy", retentionPolicy)
+      .add("createDatabase", createDatabase)
       .toString();
   }
 }

--- a/src/main/java/org/springframework/data/influxdb/InfluxDBTemplate.java
+++ b/src/main/java/org/springframework/data/influxdb/InfluxDBTemplate.java
@@ -17,8 +17,6 @@
 package org.springframework.data.influxdb;
 
 import com.google.common.base.Preconditions;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.influxdb.InfluxDB;
 import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.Pong;
@@ -26,6 +24,9 @@ import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
 import org.springframework.data.influxdb.converter.PointCollectionConverter;
 import org.springframework.util.Assert;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class InfluxDBTemplate<T> extends InfluxDBAccessor implements InfluxDBOperations<T>
 {
@@ -59,7 +60,11 @@ public class InfluxDBTemplate<T> extends InfluxDBAccessor implements InfluxDBOpe
   public void createDatabase()
   {
     final String database = getDatabase();
-    getConnection().createDatabase(database);
+    // Since Influx 1.0.0 this does only work if the database does not exist, otherwise "java.lang.RuntimeException: {"error":"error parsing query: found NOT, expected ; at line 1, char 20"}" is thrown
+    // See https://github.com/jmxtrans/jmxtrans/issues/489 for example
+    if (getCreateDatabase()) {
+      getConnection().createDatabase(database);
+    }
   }
 
   @Override


### PR DESCRIPTION
When updating influxdb to versions > 1.0.0, it will fail due to "getConnection().createDatabase(database);" since this statement does only works when the database not exists but it fails on every subsequent run..